### PR TITLE
[#1] 식당 조회 컴포넌트 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,25 +1,22 @@
 import React from 'react';
-import { atom, useRecoilState } from 'recoil';
-
-// 상태 정의
-const textState = atom({
-  key: 'textState', // 고유한 ID
-  default: '', // 기본값
-});
+import RestaurantView from './components/RestaurantView/RestaurantView';
 
 function App() {
-  const [text, setText] = useRecoilState(textState);
-
-  const onChange = (event) => {
-    setText(event.target.value);
+  // Mock Data
+  const restaurantInfo = {
+    name: "맛있는 식당",
+    thumbnail: "https://img.hankyung.com/photo/202103/0Q.25813444.1.jpg",
+    tags: ["맛집", "맛집", "맛집", "맛집", "맛집", "맛집", "맛집"]
   };
+  const restaurantInfo2 = {
+    name: "경주에서 제일 맛있는 초초초초초맛집",
+    thumbnail: "https://www.gyeongju.go.kr/upload/content/thumb/20201228/5DE22B6931D74EF9B333A081342A41F4.jpg",
+    tags: ["데이트", "가족과 함께", "가족과 함께", "한식", "경주"]
+  };
+  const restaurants = [restaurantInfo, restaurantInfo2, restaurantInfo, restaurantInfo2, restaurantInfo, restaurantInfo2, restaurantInfo, restaurantInfo2, restaurantInfo, restaurantInfo2, restaurantInfo, restaurantInfo2];
 
   return (
-    <div>
-      <input type="text" value={text} onChange={onChange} />
-      <br />
-      입력한 텍스트: {text}
-    </div>
+    <RestaurantView restaurants={restaurants}/>
   );
 }
 export default App;

--- a/src/components/RestaurantCard/RestaurantCard.css
+++ b/src/components/RestaurantCard/RestaurantCard.css
@@ -1,0 +1,56 @@
+.card {
+  width: 100%; /* 카드가 부모 요소의 너비를 초과하지 않도록 설정 */
+  max-width: 186px; /* 최대 너비를 설정하여 디자인이 유지되도록 합니다 */
+  height: 177px;
+  flex-shrink: 0;
+  border-radius: 5px;
+  border: 1px solid #D9D9D9;
+  background: #FFF;
+  padding: 6px;
+  transition: transform 0.3s ease, background-color 0.3s ease; /* 애니메이션 추가 */
+}
+
+.card:hover {
+  transform: scale(1.02); /* 살짝 확대 효과 */
+  background-color: rgba(0, 0, 0, 0.1); /* 살짝 어두워지는 효과 */
+}
+
+.card-image {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%; /* 전체 너비를 사용하도록 설정 */
+  height: 82px; /* 이미지 높이와 일치 */
+  overflow: hidden; /* 컨테이너를 넘어가는 이미지 부분을 숨김 */
+}
+
+.card-image img {
+  width: 100%; /* 이미지가 컨테이너의 전체 너비를 차지하도록 설정 */
+  height: 100%; /* 이미지가 컨테이너의 전체 높이를 차지하도록 설정 */
+  object-fit: cover; /* 이미지 비율을 유지하면서 컨테이너에 맞게 조정 */
+}
+
+.card-content h2 {
+  color: #000;
+  font-family: Inter;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  margin: 7px 0 4px 0;
+}
+
+.divider {
+  border-radius: 5px;
+  background: #D9D9D9;
+  width: 100%; /* 전체 너비를 사용하도록 설정 */
+  height: 1px;
+  flex-shrink: 0;
+}
+
+.tags {
+  width: 100%;
+  margin-top: 1px;
+  overflow: hidden;
+  height: 51px;
+}

--- a/src/components/RestaurantCard/RestaurantCard.js
+++ b/src/components/RestaurantCard/RestaurantCard.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import Tag from '../Tag/Tag';
+import './RestaurantCard.css';
+
+const RestaurantCard = ({ name, thumbnail, tags }) => {
+	const truncatedName = name.length > 13 ? `${name.slice(0, 12)}...` : name;
+
+	return (
+    <div className="card">
+			<div>
+				<div className="card-image">
+					<img src={thumbnail} alt={truncatedName} />
+				</div>
+				<div className="card-content">
+					<h2>{truncatedName}</h2>
+					<div className="divider"></div>
+					<div className="tags">
+            {tags.map((tag, index) => (
+              <Tag key={index} name={tag} />
+            ))}
+					</div>
+				</div>
+			</div>
+    </div>
+  );
+};
+
+export default RestaurantCard;

--- a/src/components/RestaurantView/RestaurantView.css
+++ b/src/components/RestaurantView/RestaurantView.css
@@ -1,0 +1,31 @@
+.restaurant-view {
+	width: 400px;
+	height: 828px;
+	flex-shrink: 0;
+	border-radius: 10px;
+	background: #F6F6F6;
+	padding: 15px;
+}
+
+.restaurant-grid-title {
+	color: #373737;
+	font-family: Inter;
+	font-size: 20px;
+	font-style: normal;
+	font-weight: 600;
+	line-height: normal;
+	margin-bottom: 10px;
+}
+
+.restaurant-grid {
+	display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 7px; /* 카드 간의 간격을 조정합니다 */
+  width: 100%; /* 그리드가 화면 너비를 초과하지 않도록 설정 */
+  box-sizing: border-box; /* 패딩과 보더를 전체 크기에 포함 */
+}
+
+.restaurant-grid-item {
+  display: flex;
+  justify-content: center;
+}

--- a/src/components/RestaurantView/RestaurantView.js
+++ b/src/components/RestaurantView/RestaurantView.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import RestaurantCard from '../RestaurantCard/RestaurantCard';
+import './RestaurantView.css';
+
+const RestaurantView = ({ restaurants }) => {
+  return (
+		<div className='restaurant-view'>
+			<div className='restaurant-grid-title'>
+				# 여긴 어때요?
+			</div>
+			<div className="restaurant-grid">
+				{restaurants.map((restaurant, index) => (
+					<div className="restaurant-grid-item" key={index}>
+						<RestaurantCard 
+							name={restaurant.name} 
+							thumbnail={restaurant.thumbnail} 
+							tags={restaurant.tags}
+						/>
+					</div>
+				))}
+			</div>
+		</div>
+  );
+};
+
+export default RestaurantView;

--- a/src/components/Tag/Tag.css
+++ b/src/components/Tag/Tag.css
@@ -1,0 +1,24 @@
+.tag {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 10px;
+  background: #F77248;
+  margin: 3px;
+  white-space: nowrap; /* 텍스트가 줄바꿈되지 않도록 설정 */
+  height: 20px;
+}
+
+.tag-content {
+  color: #FFF;
+  font-family: Inter;
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+  margin-top: 1px;
+  margin-left: 8px;
+  margin-right: 8px;
+  display: flex;
+  align-items: center; /* 자식 요소 내에서 수직 중앙 정렬 */
+}

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import './Tag.css';
+
+const Tag = ({ name }) => {
+  // 13글자를 초과할 경우 문자열을 자르고 '...'을 추가
+  const truncatedName = name.length > 13 ? `${name.slice(0, 12)}...` : name;
+
+  return (
+    <div className='tag'>
+      <span className="tag-content"># {truncatedName}</span>
+    </div>
+  );
+};
+
+export default Tag;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,14 @@
+* {
+  box-sizing: border-box;
+}
+
+html {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  overflow-x: hidden; 
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -5,9 +16,17 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  overflow-x: hidden; 
 }
 
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
+}
+
+.main {
+  padding: 10px;
 }


### PR DESCRIPTION
## 요약

식당 조회에 사용되는 컴포넌트를 구현했습니다.

## 내용

### 태그 컴포넌트

<img width="90" alt="image" src="https://github.com/What-ToEat/Frontend/assets/43935708/4fa07ea8-96b6-43aa-9024-eef82a6c5a97">

- 태그의 내용이 13글자를 초과하게 되는 경우, 1글자를 제거하고 `...`으로 대체
  - 태그 내용이 13글자를 넘게 되는 경우 레스토랑 카드 컴포넌트를 넘게 됨

### 레스토랑 카드 컴포넌트

<img width="250" alt="image" src="https://github.com/What-ToEat/Frontend/assets/43935708/4b579235-7774-4d87-a0a8-180d2781dfad">

- 레스토랑 제목이 13글자를 초과하게 되는 경우, 1글자를 제거하고 `...`으로 대체
  - 태그와 마찬가지로 13글자를 넘게 되는 경우 레스토랑 카드 컴포넌트를 넘게 됨

```css
.card:hover {
  transform: scale(1.02); /* 살짝 확대 효과 */
  background-color: rgba(0, 0, 0, 0.1); /* 살짝 어두워지는 효과 */
}
```
- 호버링 효과 추가
  - 마우스가 카드 컴포넌트에 위치할 경우 살짝 커짐
  - 모바일의 경우 호버링 효과가 적용되지 않음

### 레스토랑 조회 컴포넌트

<img width="250" alt="image" src="https://github.com/What-ToEat/Frontend/assets/43935708/eba151f0-1b48-4a28-ae9e-c8a26301461d">

```css
.restaurant-grid {
  display: grid;
  grid-template-columns: repeat(2, 1fr);
  gap: 7px; /* 카드 간의 간격을 조정합니다 */
  width: 100%; /* 그리드가 화면 너비를 초과하지 않도록 설정 */
  box-sizing: border-box; /* 패딩과 보더를 전체 크기에 포함 */
}
```
- 그리드 속성을 사용하여 2 * n으로 레스토랑 카드 컴포넌트를 배치
- 추후 [미디어 쿼리](https://developer.mozilla.org/ko/docs/Learn/CSS/CSS_layout/Media_queries)를 사용해 반응형으로 구현 예정
  - 좁은 화면인 경우 1 * n, 웹 페이지의 경우 m * n으로 배치

---

- 사용된 Mock 데이터 정보

```js
const restaurantInfo = {
    name: "맛있는 식당",
    thumbnail: "https://img.hankyung.com/photo/202103/0Q.25813444.1.jpg",
    tags: ["맛집", "맛집", "맛집", "맛집", "맛집", "맛집", "맛집"]
  };
  const restaurantInfo2 = {
    name: "경주에서 제일 맛있는 초초초초초맛집",
    thumbnail: "https://www.gyeongju.go.kr/upload/content/thumb/20201228/5DE22B6931D74EF9B333A081342A41F4.jpg",
    tags: ["데이트", "가족과 함께", "가족과 함께", "한식", "경주"]
  };
  const restaurants = [restaurantInfo, restaurantInfo2, restaurantInfo];
```

### 실행 방법

- 레포지토리 root에서 `npm start`

## 관련 이슈

- close: #1