### PR TITLE
[#5] 식당 조회 페이지 API 연결

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,12 @@
     transform: rotate(360deg);
   }
 }
+
+.viewer {
+  width: 100vw;
+  max-width: 580px;
+  height: calc(var(--vh, 1vh) * 100);
+  overflow-y: auto;
+  margin: 0 auto;
+  overscroll-behavior: contain;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,21 +1,38 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import HomePage from './pages/HomePage/HomePage';
 import ViewPage from './pages/ViewPage/ViewPage';
 import VotePage from './pages/VotePage/VotePage';
 
 function App() {
+  useEffect(() => {
+    function setScreenSize() {
+      let vh = window.innerHeight * 0.01;
+      document.documentElement.style.setProperty('--vh', `${vh}px`);
+    }
+
+    setScreenSize();
+    window.addEventListener('resize', setScreenSize);
+
+    // Cleanup function
+    return () => {
+      window.removeEventListener('resize', setScreenSize);
+    };
+  }, []);
 
   return (
     <Router>
       <div className="app">
-        <Routes>
-          <Route path="/" element={<HomePage/>} />
-          <Route path="/view" element={<ViewPage/>} />
-          <Route path="/vote" element={<VotePage/>} />
-        </Routes>
+        <div className="viewer">
+          <Routes>
+            <Route path="/" element={<HomePage />} />
+            <Route path="/view" element={<ViewPage />} />
+            <Route path="/vote" element={<VotePage />} />
+          </Routes>
+        </div>
       </div>
     </Router>
   );
 }
+
 export default App;

--- a/src/components/RestaurantCard/RestaurantCard.js
+++ b/src/components/RestaurantCard/RestaurantCard.js
@@ -16,7 +16,7 @@ const RestaurantCard = ({ name, thumbnail, tags }) => {
 					<div className="divider"></div>
 					<div className="tags">
             {tags.map((tag, index) => (
-              <Tag key={index} name={tag} />
+              <Tag key={index} name={tag.name} category={tag.category} />
             ))}
 					</div>
 				</div>

--- a/src/components/RestaurantView/RestaurantView.css
+++ b/src/components/RestaurantView/RestaurantView.css
@@ -1,6 +1,6 @@
 .restaurant-view {
 	width: 100%;
-	height: 828px;
+	height: 100%;
 	flex-shrink: 0;
 	border-radius: 10px;
 	background: #F6F6F6;

--- a/src/components/RestaurantView/RestaurantView.css
+++ b/src/components/RestaurantView/RestaurantView.css
@@ -29,3 +29,10 @@
   display: flex;
   justify-content: center;
 }
+
+.no-restaurants {
+  text-align: center;
+  color: #999;
+  font-size: 1.2em;
+  margin-top: 20px;
+}

--- a/src/components/RestaurantView/RestaurantView.js
+++ b/src/components/RestaurantView/RestaurantView.js
@@ -1,19 +1,17 @@
 import React from 'react';
 import { useRecoilValue } from 'recoil';
-import { selectedTagsState, selectedNavItemState } from '../../recoil/state';
+import { selectedTagsState } from '../../recoil/state';
 import RestaurantCard from '../RestaurantCard/RestaurantCard';
 import './RestaurantView.css';
 
 const RestaurantView = ({ restaurants }) => {
   const selectedTags = useRecoilValue(selectedTagsState);
-  const selectedNavItem = useRecoilValue(selectedNavItemState);
 
   // 필터링 함수 정의
   const filteredRestaurants = restaurants.filter((restaurant) => {
-    const isNavItemIncluded = selectedNavItem === '전체' || restaurant.tags.includes(selectedNavItem);
-    const areAllTagsIncluded = selectedTags.every(tag => restaurant.tags.includes(tag));
-
-    return isNavItemIncluded && areAllTagsIncluded;
+    const restaurantTagNames = restaurant.tags.map(tag => tag.name);
+    const areAllTagsIncluded = selectedTags.every(tag => restaurantTagNames.includes(tag));
+    return areAllTagsIncluded;
   });
 
   return (

--- a/src/components/RestaurantView/RestaurantView.js
+++ b/src/components/RestaurantView/RestaurantView.js
@@ -19,18 +19,24 @@ const RestaurantView = ({ restaurants }) => {
       <div className='restaurant-grid-title'>
         # 여긴 어때요?
       </div>
-      <div className="restaurant-grid">
-        {filteredRestaurants.map((restaurant, index) => (
-          <div className="restaurant-grid-item" key={index}>
-            <RestaurantCard 
-              name={restaurant.name} 
-              thumbnail={restaurant.thumbnail} 
-              tags={restaurant.tags}
-            />
+        {filteredRestaurants.length > 0 ? (
+          <div className="restaurant-grid"> {
+          filteredRestaurants.map((restaurant, index) => (
+            <div className="restaurant-grid-item" key={index}>
+              <RestaurantCard 
+                name={restaurant.name} 
+                thumbnail={restaurant.thumbnail} 
+                tags={restaurant.tags}
+              />
+            </div>
+          ))
+          }</div>
+        ) : (
+          <div className="no-restaurants">
+            조회된 레스토랑이 없습니다.
           </div>
-        ))}
+        )}
       </div>
-    </div>
   );
 };
 

--- a/src/components/RestaurantView/RestaurantView.js
+++ b/src/components/RestaurantView/RestaurantView.js
@@ -4,7 +4,7 @@ import { selectedTagsState } from '../../recoil/state';
 import RestaurantCard from '../RestaurantCard/RestaurantCard';
 import './RestaurantView.css';
 
-const RestaurantView = ({ restaurants }) => {
+const RestaurantView = ({ restaurants, searchKeyword }) => {
   const selectedTags = useRecoilValue(selectedTagsState);
 
   // 필터링 함수 정의
@@ -17,11 +17,11 @@ const RestaurantView = ({ restaurants }) => {
   return (
     <div className='restaurant-view'>
       <div className='restaurant-grid-title'>
-        # 여긴 어때요?
+        {searchKeyword ? `# ${searchKeyword} 검색 결과` : '# 여긴 어때요?'}
       </div>
-        {filteredRestaurants.length > 0 ? (
-          <div className="restaurant-grid"> {
-          filteredRestaurants.map((restaurant, index) => (
+      {filteredRestaurants.length > 0 ? (
+        <div className="restaurant-grid">
+          {filteredRestaurants.map((restaurant, index) => (
             <div className="restaurant-grid-item" key={index}>
               <RestaurantCard 
                 name={restaurant.name} 
@@ -29,14 +29,14 @@ const RestaurantView = ({ restaurants }) => {
                 tags={restaurant.tags}
               />
             </div>
-          ))
-          }</div>
-        ) : (
-          <div className="no-restaurants">
-            조회된 레스토랑이 없습니다.
-          </div>
-        )}
-      </div>
+          ))}
+        </div>
+      ) : (
+        <div className="no-restaurants">
+          조회된 레스토랑이 없습니다.
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -1,11 +1,27 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './SearchBar.css';
 
-const SearchBar = () => {
+const SearchBar = ({ onSearch }) => {
+  const [keyword, setKeyword] = useState('');
+
+  const handleInputChange = (event) => {
+    setKeyword(event.target.value);
+  };
+
+  const handleSearchClick = () => {
+    onSearch(keyword);
+  };
+
   return (
     <div className="search-bar">
-      <input type="text" placeholder="식당 검색" className="search-input" />
-      <button className="search-button">
+      <input 
+        type="text" 
+        placeholder="식당 검색" 
+        className="search-input" 
+        value={keyword}
+        onChange={handleInputChange}
+      />
+      <button className="search-button" onClick={handleSearchClick}>
         <i className="fas fa-search"></i>
       </button>
     </div>

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -12,6 +12,12 @@ const SearchBar = ({ onSearch }) => {
     onSearch(keyword);
   };
 
+  const handleKeyPress = (event) => {
+    if (event.key === 'Enter') {
+      handleSearchClick();
+    }
+  };
+
   return (
     <div className="search-bar">
       <input 
@@ -20,6 +26,7 @@ const SearchBar = ({ onSearch }) => {
         className="search-input" 
         value={keyword}
         onChange={handleInputChange}
+        onKeyDown={handleKeyPress}
       />
       <button className="search-button" onClick={handleSearchClick}>
         <i className="fas fa-search"></i>

--- a/src/components/Tag/SelectableTag.js
+++ b/src/components/Tag/SelectableTag.js
@@ -3,7 +3,7 @@ import { useRecoilState } from 'recoil';
 import { selectedTagsState } from '../../recoil/state';
 import './SelectableTag.css';
 
-const SelectableTag = ({ name }) => {
+const SelectableTag = ({ name, category }) => {
   const [selectedTags, setSelectedTags] = useRecoilState(selectedTagsState);
 
   const isSelected = selectedTags.includes(name);

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import './Tag.css';
 
-const Tag = ({ name }) => {
+const Tag = ({ name, category }) => {
   // 13글자를 초과할 경우 문자열을 자르고 '...'을 추가
   const truncatedName = name.length > 13 ? `${name.slice(0, 12)}...` : name;
 

--- a/src/components/TagList/TagList.js
+++ b/src/components/TagList/TagList.js
@@ -31,7 +31,7 @@ const TagList = ({ tags }) => {
           ref={tagListRef}
         >
           {tags.map((tag) => (
-            <SelectableTag key={tag} name={tag} />
+            <SelectableTag key={tag.name} name={tag.name} category={tag.category} />
           ))}
         </div>
         <div className="toggle-button-container">

--- a/src/index.css
+++ b/src/index.css
@@ -2,11 +2,16 @@
   box-sizing: border-box;
 }
 
+:root {
+  --vh: 1vh;
+}
+
 html {
   margin: 0;
   padding: 0;
   width: 100%;
-  overflow-x: hidden; 
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
 }
 
 body {
@@ -16,10 +21,10 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  margin: 0;
-  padding: 0;
   width: 100%;
-  overflow-x: hidden; 
+  overflow-x: hidden;
+  box-sizing: border-box;
+  overscroll-behavior: none;
 }
 
 code {

--- a/src/pages/ViewPage/ViewPage.js
+++ b/src/pages/ViewPage/ViewPage.js
@@ -14,7 +14,7 @@ const ViewPage = () => {
   const [restaurants, setRestaurants] = useState([]);
   const [selectedNavItem, setSelectedNavItem] = useRecoilState(selectedNavItemState);
   const [, setSelectedTags] = useRecoilState(selectedTagsState);
-  const [searchResults, setSearchResults] = useState([]);
+  const [searchResults, setSearchResults] = useState(null);
 
   useEffect(() => {
     fetch("http://43.202.161.19:8080/api/tags")
@@ -34,7 +34,7 @@ const ViewPage = () => {
       .then(({data: {restaurants}}) => {
         setRestaurants(restaurants);
         setSelectedTags([]); // Reset selected tags
-        setSearchResults([]);
+        setSearchResults(null);
       })
       .catch(error => console.error('Error fetching restaurants:', error));
   }, [selectedNavItem]);
@@ -57,7 +57,7 @@ const ViewPage = () => {
       <SearchBar onSearch={handleSearch} />
       <TagNav/>
       <TagList tags={tags}/>
-			<RestaurantView restaurants={searchResults.length > 0 ? searchResults : restaurants}/>
+			<RestaurantView restaurants={searchResults !== null ? searchResults : restaurants}/>
 		</div>
   );
 };

--- a/src/pages/ViewPage/ViewPage.js
+++ b/src/pages/ViewPage/ViewPage.js
@@ -5,11 +5,15 @@ import Logo from '../../components/Logo/Logo'
 import SearchBar from '../../components/SearchBar/SearchBar'
 import TagNav from '../../components/TagNav/TagNav';
 import TagList from '../../components/TagList/TagList';
+import { useRecoilState } from 'recoil';
+import { selectedTagsState, selectedNavItemState } from '../../recoil/state';
 
-import { mockRestaurants } from './mock.js';
 
 const ViewPage = () => {
   const [tags, setTags] = useState([]);
+  const [restaurants, setRestaurants] = useState([]);
+  const [selectedNavItem, setSelectedNavItem] = useRecoilState(selectedNavItemState);
+  const [selectedTags, setSelectedTags] = useRecoilState(selectedTagsState);
 
   useEffect(() => {
     fetch("http://43.202.161.19:8080/api/tags")
@@ -18,13 +22,28 @@ const ViewPage = () => {
       .catch(error => console.error('Error fetching tags:', error));
   }, []);
 
+  useEffect(() => {
+    let url = 'http://43.202.161.19:8080/api/restaurants/tag?page=1';
+    if (selectedNavItem !== '전체') {
+        url += `&place=${selectedNavItem}`;
+    }
+
+    fetch(url)
+      .then(response => response.json())
+      .then(({data: {restaurants}}) => {
+        setRestaurants(restaurants);
+        setSelectedTags([]); // Reset selected tags
+      })
+      .catch(error => console.error('Error fetching restaurants:', error));
+  }, [selectedNavItem]);
+
   return (
     <div className='view-page'>
       <Logo/>
       <SearchBar/>
       <TagNav/>
       <TagList tags={tags}/>
-			<RestaurantView restaurants={mockRestaurants}/>
+			<RestaurantView restaurants={restaurants}/>
 		</div>
   );
 };

--- a/src/pages/ViewPage/ViewPage.js
+++ b/src/pages/ViewPage/ViewPage.js
@@ -13,7 +13,8 @@ const ViewPage = () => {
   const [tags, setTags] = useState([]);
   const [restaurants, setRestaurants] = useState([]);
   const [selectedNavItem, setSelectedNavItem] = useRecoilState(selectedNavItemState);
-  const [selectedTags, setSelectedTags] = useRecoilState(selectedTagsState);
+  const [, setSelectedTags] = useRecoilState(selectedTagsState);
+  const [searchResults, setSearchResults] = useState([]);
 
   useEffect(() => {
     fetch("http://43.202.161.19:8080/api/tags")
@@ -33,17 +34,30 @@ const ViewPage = () => {
       .then(({data: {restaurants}}) => {
         setRestaurants(restaurants);
         setSelectedTags([]); // Reset selected tags
+        setSearchResults([]);
       })
       .catch(error => console.error('Error fetching restaurants:', error));
   }, [selectedNavItem]);
 
+  const handleSearch = (keyword) => {
+    const url = `http://43.202.161.19:8080/api/restaurants/keyword?keyword=${keyword}&page=1`;
+
+    fetch(url)
+      .then(response => response.json())
+      .then(({data: {restaurants}}) => {
+        setSearchResults(restaurants);
+        setSelectedTags([]);
+      })
+      .catch(error => console.error('Error fetching restaurants:', error));
+  };
+
   return (
     <div className='view-page'>
       <Logo/>
-      <SearchBar/>
+      <SearchBar onSearch={handleSearch} />
       <TagNav/>
       <TagList tags={tags}/>
-			<RestaurantView restaurants={restaurants}/>
+			<RestaurantView restaurants={searchResults.length > 0 ? searchResults : restaurants}/>
 		</div>
   );
 };

--- a/src/pages/ViewPage/ViewPage.js
+++ b/src/pages/ViewPage/ViewPage.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import './ViewPage.css';
 import RestaurantView from '../../components/RestaurantView/RestaurantView';
 import Logo from '../../components/Logo/Logo'
@@ -6,21 +6,27 @@ import SearchBar from '../../components/SearchBar/SearchBar'
 import TagNav from '../../components/TagNav/TagNav';
 import TagList from '../../components/TagList/TagList';
 
-import { mockRestaurants, mockTags } from './mock.js';
+import { mockRestaurants } from './mock.js';
 
 const ViewPage = () => {
+  const [tags, setTags] = useState([]);
+
+  useEffect(() => {
+    fetch("http://43.202.161.19:8080/api/tags")
+      .then(response => response.json())
+      .then(({data: {tags}}) => setTags(tags))
+      .catch(error => console.error('Error fetching tags:', error));
+  }, []);
 
   return (
     <div className='view-page'>
       <Logo/>
       <SearchBar/>
       <TagNav/>
-      <TagList tags={mockTags}/>
+      <TagList tags={tags}/>
 			<RestaurantView restaurants={mockRestaurants}/>
 		</div>
   );
 };
 
 export default ViewPage;
-
-

--- a/src/pages/ViewPage/ViewPage.js
+++ b/src/pages/ViewPage/ViewPage.js
@@ -15,6 +15,7 @@ const ViewPage = () => {
   const [selectedNavItem, setSelectedNavItem] = useRecoilState(selectedNavItemState);
   const [, setSelectedTags] = useRecoilState(selectedTagsState);
   const [searchResults, setSearchResults] = useState(null);
+  const [searchKeyword, setSearchKeyword] = useState('');
 
   useEffect(() => {
     fetch("http://43.202.161.19:8080/api/tags")
@@ -35,6 +36,7 @@ const ViewPage = () => {
         setRestaurants(restaurants);
         setSelectedTags([]); // Reset selected tags
         setSearchResults(null);
+        setSearchKeyword('');
       })
       .catch(error => console.error('Error fetching restaurants:', error));
   }, [selectedNavItem]);
@@ -47,6 +49,7 @@ const ViewPage = () => {
       .then(({data: {restaurants}}) => {
         setSearchResults(restaurants);
         setSelectedTags([]);
+        setSearchKeyword(keyword);
       })
       .catch(error => console.error('Error fetching restaurants:', error));
   };
@@ -57,7 +60,10 @@ const ViewPage = () => {
       <SearchBar onSearch={handleSearch} />
       <TagNav/>
       <TagList tags={tags}/>
-			<RestaurantView restaurants={searchResults !== null ? searchResults : restaurants}/>
+			<RestaurantView 
+        restaurants={searchResults !== null ? searchResults : restaurants} 
+        searchKeyword={searchKeyword} 
+      />
 		</div>
   );
 };


### PR DESCRIPTION
## 요약

식당 조회 페이지에 API를 연결했습니다.

## 내용

### 태그 목록 API 연결

- useEffect를 사용하여 최초 렌더링 시 태그 목록을 가져옴
- 추후 확장성을 고려해 Tag 컴포넌트와  SelectableTag 컴포넌트에 카테고리 항목을 추가

### 레스토랑 목록 조회 API 연결

- 검색 지역을 바꿀 때마다 해당 지역 레스토랑 목록을 요청
- 검색 지역을 바꾸는 경우 선택되어 있던 태그를 모두 해제
- 조회된 식당이 없는 경우 "조회된 레스토랑이 없습니다"라는 문구를 출력

### 레스토랑 검색 API 연결

<img width="350" alt="image" src="https://github.com/What-ToEat/Frontend/assets/43935708/d36409a7-c255-43f5-8b4f-0d315655cb8c">
<img width="350" alt="image" src="https://github.com/What-ToEat/Frontend/assets/43935708/9274cb29-f45f-4818-aa3c-4285a84584cf">


- 검색창에서 식당 이름으로 레스토랑 목록을 불러오도록함
- 검색 단어를 레스토랑 목록 상단에 출력하도록 함

### issue

- 현재 식당 목록을 1페이지 (10개)만 받아오고 있음
  - 추가 목록을 언제, 어떻게 받아올지 고민해야함
- 현재 식당 조회 API에서는 지역, 태그로 식당 목록을 가져오고 있음
  - 태그를 누를 때마다 매번 API 요청을 보낼 경우 로딩 속도가 오래 걸려 SPA의 장점이 사라짐
  - 우선 지역을 누를 때마다 1페이지 로딩했지만 지역 데이터를 모두 받아오기엔 시간이 오래 걸림


## 참고 영상

### 식당 검색

https://github.com/What-ToEat/Frontend/assets/43935708/e5c98f40-9853-428c-924e-0762206fabae

### 지역별 조회

https://github.com/What-ToEat/Frontend/assets/43935708/5ee6b456-c7ba-4363-acfc-f4124ffdc9a0

### 스크롤

https://github.com/What-ToEat/Frontend/assets/43935708/b4887211-24c1-409c-bb67-3b82852de86c

## 관련 이슈

- close: #5 