### PR TITLE
[#7] 레스토랑 조회 로직 수정 및 무한 스크롤 적용

### DIFF
--- a/src/components/RestaurantCard/RestaurantCard.js
+++ b/src/components/RestaurantCard/RestaurantCard.js
@@ -3,7 +3,7 @@ import Tag from '../Tag/Tag';
 import './RestaurantCard.css';
 
 const RestaurantCard = ({ name, thumbnail, tags }) => {
-	const truncatedName = name.length > 13 ? `${name.slice(0, 12)}...` : name;
+	const truncatedName = name.length > 11 ? `${name.slice(0, 10)}...` : name;
 
 	return (
     <div className="card">

--- a/src/components/RestaurantView/RestaurantView.css
+++ b/src/components/RestaurantView/RestaurantView.css
@@ -5,6 +5,7 @@
 	border-radius: 10px;
 	background: #F6F6F6;
 	padding: 15px;
+	min-height: 500px;
 }
 
 .restaurant-grid-title {

--- a/src/components/RestaurantView/RestaurantView.js
+++ b/src/components/RestaurantView/RestaurantView.js
@@ -7,21 +7,14 @@ import './RestaurantView.css';
 const RestaurantView = ({ restaurants, searchKeyword }) => {
   const selectedTags = useRecoilValue(selectedTagsState);
 
-  // 필터링 함수 정의
-  const filteredRestaurants = restaurants.filter((restaurant) => {
-    const restaurantTagNames = restaurant.tags.map(tag => tag.name);
-    const areAllTagsIncluded = selectedTags.every(tag => restaurantTagNames.includes(tag));
-    return areAllTagsIncluded;
-  });
-
   return (
     <div className='restaurant-view'>
       <div className='restaurant-grid-title'>
         {searchKeyword ? `# ${searchKeyword} 검색 결과` : '# 여긴 어때요?'}
       </div>
-      {filteredRestaurants.length > 0 ? (
+      {restaurants.length > 0 ? (
         <div className="restaurant-grid">
-          {filteredRestaurants.map((restaurant, index) => (
+          {restaurants.map((restaurant, index) => (
             <div className="restaurant-grid-item" key={index}>
               <RestaurantCard 
                 name={restaurant.name} 

--- a/src/components/Tag/SelectableTag.css
+++ b/src/components/Tag/SelectableTag.css
@@ -23,7 +23,7 @@
   color: #ffffff;
 	border-radius: 10px;
 	border: 0;
-	padding: 1px 1px;
+  border: 1px solid #F77248;
 }
 
 .selectable-tag-content {

--- a/src/components/TagList/TagList.css
+++ b/src/components/TagList/TagList.css
@@ -17,6 +17,12 @@
   padding-bottom: 5px;
 }
 
+.tag-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .tag-list-title {
   color: #C15533;
   font-family: Inter;
@@ -25,6 +31,17 @@
   font-weight: 600;
   line-height: normal;
   margin-left: 3px;
+}
+
+.tag-list-search-button {
+  background-color: #F77248;
+  color: white;
+  border: none;
+  border-radius: 3px;
+  padding: 5px 10px;
+  font-size: 13px;
+  cursor: pointer;
+  margin-right: 3px;
 }
 
 .tag-list.collapsed {

--- a/src/components/TagList/TagList.js
+++ b/src/components/TagList/TagList.js
@@ -4,7 +4,7 @@ import { isTagListExpandedState } from '../../recoil/state';
 import SelectableTag from '../Tag/SelectableTag';
 import './TagList.css';
 
-const TagList = ({ tags }) => {
+const TagList = ({ tags, onSearch }) => {
   const [isExpanded, setIsExpanded] = useRecoilState(isTagListExpandedState);
   const [maxHeight, setMaxHeight] = useState('109px');
   const tagListRef = useRef(null);
@@ -21,15 +21,11 @@ const TagList = ({ tags }) => {
     setIsExpanded(!isExpanded);
   };
 
-  const handleSearch = () => {
-    console.log('Search button clicked');
-  };
-
   return (
     <div className='tag-list-wrapper'>
       <div className='tag-list-header'>
         <span className='tag-list-title'># 태그</span>
-        <button className='tag-list-search-button' onClick={handleSearch}>조회하기</button>
+        <button className='tag-list-search-button' onClick={onSearch}>조회하기</button>
       </div>
       <div className="tag-list-container">
         <div

--- a/src/components/TagList/TagList.js
+++ b/src/components/TagList/TagList.js
@@ -21,9 +21,16 @@ const TagList = ({ tags }) => {
     setIsExpanded(!isExpanded);
   };
 
+  const handleSearch = () => {
+    console.log('Search button clicked');
+  };
+
   return (
     <div className='tag-list-wrapper'>
-      <span className='tag-list-title'># 태그</span>
+      <div className='tag-list-header'>
+        <span className='tag-list-title'># 태그</span>
+        <button className='tag-list-search-button' onClick={handleSearch}>조회하기</button>
+      </div>
       <div className="tag-list-container">
         <div
           className={`tag-list ${isExpanded ? 'expanded' : 'collapsed'}`}

--- a/src/pages/ViewPage/ViewPage.css
+++ b/src/pages/ViewPage/ViewPage.css
@@ -1,3 +1,37 @@
 .view-page {
-	margin: 20px 15px 0px 15px;
+  margin: 20px 15px 0px 15px;
+}
+
+.view-page-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: Inter, sans-serif;
+  font-size: 1.5em;
+  font-weight: 600;
+  color: #F77248; /* 메인 컬러 사용 */
+  position: fixed; /* 스크롤 시 고정 */
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.spinner {
+  border: 4px solid rgba(255, 255, 255, 0.3);
+  border-top: 4px solid #F77248; /* 메인 컬러 사용 */
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+  margin-right: 10px;
 }

--- a/src/pages/ViewPage/ViewPage.js
+++ b/src/pages/ViewPage/ViewPage.js
@@ -13,7 +13,7 @@ const ViewPage = () => {
   const [tags, setTags] = useState([]);
   const [restaurants, setRestaurants] = useState([]);
   const [selectedNavItem, setSelectedNavItem] = useRecoilState(selectedNavItemState);
-  const [, setSelectedTags] = useRecoilState(selectedTagsState);
+  const [selectedTags, setSelectedTags] = useRecoilState(selectedTagsState);
   const [searchResults, setSearchResults] = useState(null);
   const [searchKeyword, setSearchKeyword] = useState('');
 
@@ -54,12 +54,32 @@ const ViewPage = () => {
       .catch(error => console.error('Error fetching restaurants:', error));
   };
 
+  const handleTagSearch = () => {
+    let url = 'http://43.202.161.19:8080/api/restaurants/tag?page=1';
+    if (selectedNavItem !== '전체') {
+      url += `&place=${encodeURIComponent(selectedNavItem)}`;
+    }
+    if (selectedTags.length > 0) {
+      const tagParams = selectedTags.map(tag => `tags=${encodeURIComponent(tag)}`).join('&');
+      url += `&${tagParams}`;
+    }
+
+    fetch(url)
+      .then(response => response.json())
+      .then(({data: {restaurants}}) => {
+        setRestaurants(restaurants);
+        setSearchResults(null);
+        setSearchKeyword('');
+      })
+      .catch(error => console.error('Error fetching restaurants:', error));
+  };
+
   return (
     <div className='view-page'>
       <Logo/>
       <SearchBar onSearch={handleSearch} />
       <TagNav/>
-      <TagList tags={tags}/>
+      <TagList tags={tags} onSearch={handleTagSearch}/>
 			<RestaurantView 
         restaurants={searchResults !== null ? searchResults : restaurants} 
         searchKeyword={searchKeyword} 

--- a/src/pages/ViewPage/ViewPage.js
+++ b/src/pages/ViewPage/ViewPage.js
@@ -147,7 +147,12 @@ const ViewPage = () => {
         restaurants={searchResults !== null ? searchResults : restaurants} 
         searchKeyword={searchKeyword} 
       />
-      {isLoading && <div className="view-page-loading">Loading...</div>}
+      {isLoading && (
+        <div className="view-page-loading">
+          <div className="spinner"></div>
+          Loading...
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/ViewPage/ViewPage.js
+++ b/src/pages/ViewPage/ViewPage.js
@@ -1,13 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import './ViewPage.css';
 import RestaurantView from '../../components/RestaurantView/RestaurantView';
-import Logo from '../../components/Logo/Logo'
-import SearchBar from '../../components/SearchBar/SearchBar'
+import Logo from '../../components/Logo/Logo';
+import SearchBar from '../../components/SearchBar/SearchBar';
 import TagNav from '../../components/TagNav/TagNav';
 import TagList from '../../components/TagList/TagList';
 import { useRecoilState } from 'recoil';
 import { selectedTagsState, selectedNavItemState } from '../../recoil/state';
-
 
 const ViewPage = () => {
   const [tags, setTags] = useState([]);
@@ -16,11 +15,14 @@ const ViewPage = () => {
   const [selectedTags, setSelectedTags] = useRecoilState(selectedTagsState);
   const [searchResults, setSearchResults] = useState(null);
   const [searchKeyword, setSearchKeyword] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
 
   useEffect(() => {
     fetch("http://43.202.161.19:8080/api/tags")
       .then(response => response.json())
-      .then(({data: {tags}}) => setTags(tags))
+      .then(({ data: { tags } }) => setTags(tags))
       .catch(error => console.error('Error fetching tags:', error));
   }, []);
 
@@ -30,6 +32,8 @@ const ViewPage = () => {
         url += `&place=${selectedNavItem}`;
     }
 
+    setIsLoading(true);
+
     fetch(url)
       .then(response => response.json())
       .then(({data: {restaurants}}) => {
@@ -37,24 +41,76 @@ const ViewPage = () => {
         setSelectedTags([]); // Reset selected tags
         setSearchResults(null);
         setSearchKeyword('');
+        setCurrentPage(1); // Reset current page
+        setHasMore(restaurants.length > 0); // Set hasMore based on initial data
+        setIsLoading(false);
       })
-      .catch(error => console.error('Error fetching restaurants:', error));
+      .catch(error => {
+        console.error('Error fetching restaurants:', error);
+        setIsLoading(false);
+      });
   }, [selectedNavItem]);
 
-  const handleSearch = (keyword) => {
-    const url = `http://43.202.161.19:8080/api/restaurants/keyword?keyword=${keyword}&page=1`;
+  useEffect(() => {
+    const handleScroll = () => {
+      if (window.innerHeight + document.documentElement.scrollTop >= document.documentElement.offsetHeight - 100 && !isLoading && hasMore) {
+        loadMoreRestaurants();
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [isLoading, hasMore, currentPage, selectedNavItem, selectedTags]);
+
+  const loadMoreRestaurants = () => {
+    const nextPage = currentPage + 1;
+    let url = `http://43.202.161.19:8080/api/restaurants/tag?page=${nextPage}`;
+    if (selectedNavItem !== '전체') {
+      url += `&place=${encodeURIComponent(selectedNavItem)}`;
+    }
+    if (selectedTags.length > 0) {
+      const tagParams = selectedTags.map(tag => `tags=${encodeURIComponent(tag)}`).join('&');
+      url += `&${tagParams}`;
+    }
+
+    setIsLoading(true);
 
     fetch(url)
       .then(response => response.json())
-      .then(({data: {restaurants}}) => {
-        setSearchResults(restaurants);
-        setSelectedTags([]);
-        setSearchKeyword(keyword);
+      .then(({ data: { restaurants: fetchedRestaurants } }) => {
+        setRestaurants(prevRestaurants => [...prevRestaurants, ...fetchedRestaurants]);
+        setCurrentPage(nextPage); // Update current page
+        setHasMore(fetchedRestaurants.length > 0); // Check if more data is available
+        setIsLoading(false);
       })
-      .catch(error => console.error('Error fetching restaurants:', error));
+      .catch(error => {
+        console.error('Error fetching more restaurants:', error);
+        setIsLoading(false);
+      });
+  };
+
+  const handleSearch = (keyword) => {
+    const url = `http://43.202.161.19:8080/api/restaurants/keyword?keyword=${encodeURIComponent(keyword)}&page=1`;
+
+    setIsLoading(true);
+
+    fetch(url)
+      .then(response => response.json())
+      .then(({ data: { restaurants } }) => {
+        setSearchResults(restaurants);
+        setSearchKeyword(keyword);
+        setIsLoading(false);
+        setCurrentPage(1); // Reset current page
+        setHasMore(restaurants.length > 0); // Set hasMore based on search results
+      })
+      .catch(error => {
+        console.error('Error fetching restaurants:', error);
+        setIsLoading(false);
+      });
   };
 
   const handleTagSearch = () => {
+    setCurrentPage(1);
     let url = 'http://43.202.161.19:8080/api/restaurants/tag?page=1';
     if (selectedNavItem !== '전체') {
       url += `&place=${encodeURIComponent(selectedNavItem)}`;
@@ -64,27 +120,35 @@ const ViewPage = () => {
       url += `&${tagParams}`;
     }
 
+    setIsLoading(true);
+
     fetch(url)
       .then(response => response.json())
-      .then(({data: {restaurants}}) => {
-        setRestaurants(restaurants);
+      .then(({ data: { restaurants: fetchedRestaurants } }) => {
+        setRestaurants(fetchedRestaurants);
         setSearchResults(null);
         setSearchKeyword('');
+        setIsLoading(false);
+        setHasMore(fetchedRestaurants.length > 0); // Set hasMore based on tag search results
       })
-      .catch(error => console.error('Error fetching restaurants:', error));
+      .catch(error => {
+        console.error('Error fetching restaurants:', error);
+        setIsLoading(false);
+      });
   };
 
   return (
     <div className='view-page'>
-      <Logo/>
+      <Logo />
       <SearchBar onSearch={handleSearch} />
-      <TagNav/>
-      <TagList tags={tags} onSearch={handleTagSearch}/>
-			<RestaurantView 
+      <TagNav />
+      <TagList tags={tags} onSearch={handleTagSearch} />
+      <RestaurantView 
         restaurants={searchResults !== null ? searchResults : restaurants} 
         searchKeyword={searchKeyword} 
       />
-		</div>
+      {isLoading && <div className="view-page-loading">Loading...</div>}
+    </div>
   );
 };
 


### PR DESCRIPTION
## 요약

레스토랑 조회 로직을 수정하고 무한 스크롤을 적용했습니다.

## 내용

### 태그 크기 오류 수정

- 선택 가능한 태그의 크기가 일반 태그에 비해 작았던 오류 수정

### 레스토랑 조회 로직 수정

- 기존에는 지역을 선택하면 API를 1회 호출한 뒤, 태그들로 필터링 하는 방식을 사용했음
  - 레스토랑의 개수가 너무 많아 이와 같은 방식 대신 무한스크롤 방식을 도입하기로 함

- 태그를 선택한 뒤, "조회하기"라는 버튼을 누르면 API 요청이 감
- 스크롤이 맨 끝에 도달했을 때 다음 Page 레스토랑 목록 API를 다시 요청

### 로딩중 모달 추가

- fetch를 진행하고 있을 때 Loading이라는 문구가 담긴 모달 출력

## 참고 영상

https://github.com/What-ToEat/Frontend/assets/43935708/54a6b85a-0aac-4213-811a-1522ff776ff9


## 관련 이슈

- close: #7 
